### PR TITLE
Refactoring mock

### DIFF
--- a/test/app/music-library/useMusicLibraryViewModel.test.ts
+++ b/test/app/music-library/useMusicLibraryViewModel.test.ts
@@ -1,7 +1,7 @@
 import {act, renderHook} from "@testing-library/react";
 import {useMusicLibraryViewModel} from "@/app/music-library/useMusicLibraryViewModel";
 
-import * as PlayQueueContextModule from '@/app/contexts/PlayQueueContext';
+import { usePlayQueueContext } from '@/app/contexts/PlayQueueContext';
 
 jest.mock('@/app/contexts/PlayQueueContext', () => ({
     __esModule: true,
@@ -10,13 +10,15 @@ jest.mock('@/app/contexts/PlayQueueContext', () => ({
 
 const mockUpdateCurrentTrack = jest.fn();
 
-const mockUsePlayQueueContext = PlayQueueContextModule.usePlayQueueContext as jest.MockedFunction<typeof PlayQueueContextModule.usePlayQueueContext>;
-mockUsePlayQueueContext.mockReturnValue({
-    currentTrack: '',
-    updateCurrentTrack: mockUpdateCurrentTrack
-});
-
 describe("MusicLibraryViewModel", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (usePlayQueueContext as jest.Mock).mockReturnValue({
+            currentTrack: '',
+            updateCurrentTrack: mockUpdateCurrentTrack
+        });
+    })
+
     it("should upload a song file", () => {
         const {result} = renderHook(() => useMusicLibraryViewModel());
 


### PR DESCRIPTION
## Como funciona
- A linha 4 importa o que queremos
- A linha 6 diz que o ''@/app/contexts/PlayQueueContext'' inteiro é mock, e especifica o usePlayQueueContext como mock jest.fn()
- A linha 13 especifica o que o usePlayQueueContext deve retornar

- A linha 6 poderia ser apenas `jest.mock('@/app/contexts/PlayQueueContext');` se tivermos o jest.config.ts configurado corretamente